### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {
-    "grunt":"~0.4.1", 
-    "grunt-contrib-jshint":"~0.6.2",
-    "grunt-contrib-concat":"~0.3.0",
-    "grunt-contrib-uglify":"~0.2.2",
-    "grunt-contrib-cssmin":"~0.6.1",
-    "grunt-contrib-htmlmin":"~0.1.3",
-    "grunt-contrib-copy":"~0.4.0"
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.6.2",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-contrib-cssmin": "~0.6.1",
+    "grunt-contrib-htmlmin": "~0.1.3",
+    "grunt-contrib-copy": "~0.4.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"
@@ -41,9 +41,9 @@
       "url": "https://donghanji.github.com"
     }
   ],
-  "repository":{
-	"type":"git",
-	"url":"git://github.com/donghanji/compressor.git"
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/donghanji/compressor.git"
   },
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)